### PR TITLE
Fix CI/CD build failures

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -78,21 +78,8 @@ jobs:
         uses: bluefireteam/melos-action@ec2c512a52c2f359186ca19bac0be977c44913e6
         with:
           melos-version: "6.0.0"
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ runner.os }}-build-artifact
-        continue-on-error: true
       - name: "Run build for Android"
         run: melos run flutter-build-android
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ runner.os }}-build-artifact
-          include-hidden-files: true
-          path: build
-          retention-days: 1
-          overwrite: true
 
   build-ios:
     name: Build iOS
@@ -124,20 +111,7 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('**/*.podspec') }}
           restore-keys: |
             ${{ runner.os }}-pods-
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ runner.os }}-build-artifact
-        continue-on-error: true
       - name: Select XCode 16.1
         run: sudo xcode-select -s '/Applications/Xcode_16.1.0.app/Contents/Developer'
       - name: "Run build for iOS"
         run: melos run flutter-build-ios
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ runner.os }}-build-artifact
-          include-hidden-files: true
-          path: build
-          retention-days: 1
-          overwrite: true

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ runner.os }}-build-artifact
+        continue-on-error: true
       - name: "Run build for Android"
         run: melos run flutter-build-android
       - name: Upload build artifact
@@ -127,6 +128,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ runner.os }}-build-artifact
+        continue-on-error: true
       - name: Select XCode 16.1
         run: sudo xcode-select -s '/Applications/Xcode_16.1.0.app/Contents/Developer'
       - name: "Run build for iOS"

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on:
       labels: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v4
         name: Checkout code
       - uses: actions/setup-java@v4
         name: Setup java
@@ -61,7 +61,7 @@ jobs:
       MAPS_API_KEY: ${{ secrets.ACTIONS_API_KEY }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4
       - name: Setup java
         uses: actions/setup-java@v4
         with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build samples](https://github.com/googlemaps-samples/flutter-maps-samples/actions/workflows/test-and-build.yaml/badge.svg?branch=main)](https://github.com/googlemaps-samples/flutter-maps-samples/actions/workflows/test-and-build.yaml)
 [![Discord](https://img.shields.io/discord/676948200904589322)](https://discord.gg/hYsWbmk)
 
-
 Google Maps SDK for Flutter sample code
 =======================================
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build samples](https://github.com/googlemaps-samples/flutter-maps-samples/actions/workflows/test-and-build.yaml/badge.svg?branch=main)](https://github.com/googlemaps-samples/flutter-maps-samples/actions/workflows/test-and-build.yaml)
 [![Discord](https://img.shields.io/discord/676948200904589322)](https://discord.gg/hYsWbmk)
 
+
 Google Maps SDK for Flutter sample code
 =======================================
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,7 +22,9 @@ plugins {
 android {
     namespace = "com.example.flutter_maps_samples"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // The Google Maps plugin needs a higher version of NDK than
+    // Flutter's default (flutter.ndkVersion).
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip


### PR DESCRIPTION
Fix build failures:

- Android and iOS artifacts not found
- Higher NDK version required than what's default by Flutter
- Use of a specific checkout version (not needed)
- Gradle version too low for current version of Flutter