### PR TITLE
Stop controlling android gradle deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,13 +21,6 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: chore(deps)
-  - package-ecosystem: "gradle"
-    directory: "/android" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: chore(deps)
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
If we had a bunch of plugins that we manage ourselves, that’s one thing, but this is a sample whose only dependencies are through flutter_google_maps. The dependencies are literally just

```
    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
    id "com.android.application" version "8.9.0" apply false
    id "org.jetbrains.kotlin.android" version "2.1.10" apply false
```

and typically, they don't change in Flutter apps. If they must change, it's something that the `flutter` CLI tool can help with.