### PR TITLE
Handle disposed map correctly

### DIFF
--- a/lib/samples/camera_animate.dart
+++ b/lib/samples/camera_animate.dart
@@ -47,6 +47,12 @@ class _AnimateCameraSampleState extends State<AnimateCameraSample> {
     );
   }
 
+  @override
+  void dispose() {
+    _controller = null;
+    super.dispose();
+  }
+
   /// Called when the button is pressed.
   void _onPressed() {
     // Set up the desired camera update.

--- a/lib/samples/camera_move.dart
+++ b/lib/samples/camera_move.dart
@@ -47,6 +47,12 @@ class _MoveCameraSampleState extends State<MoveCameraSample> {
     );
   }
 
+  @override
+  void dispose() {
+    _controller = null;
+    super.dispose();
+  }
+
   /// Called when the button is pressed.
   void _onPressed() {
     // Set up the desired camera update.

--- a/lib/samples/map_controller_async.dart
+++ b/lib/samples/map_controller_async.dart
@@ -76,6 +76,9 @@ class _MapControllerAsyncSampleState extends State<MapControllerAsyncSample> {
     // if the controller value is already available.
     final controller = await _completer.future;
 
+    // Bail out if the widget is already disposed.
+    if (!mounted) return;
+
     // Use the controller.
     controller.animateCamera(CameraUpdate.zoomIn());
   }


### PR DESCRIPTION
It's possible to get an error when an asynchronous API is accessed through the map controller at the same time when the `GoogleMap` widget is being disposed. To prevent this, one should set the controller field to `null` in `dispose()`, or check `mounted` state before each use of the controller.

This adds these guards to each appropriate sample.