### PR TITLE
Add region tags to samples

### DIFF
--- a/lib/samples/basic.dart
+++ b/lib/samples/basic.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 /// This example creates a map using the [GoogleMap] widget.
+// [START maps_flutter_basic]
 class BasicSample extends StatelessWidget {
   const BasicSample({super.key});
 
@@ -27,3 +28,4 @@ class BasicSample extends StatelessWidget {
     );
   }
 }
+// [END maps_flutter_basic]

--- a/lib/samples/camera_animate.dart
+++ b/lib/samples/camera_animate.dart
@@ -25,6 +25,7 @@ class AnimateCameraSample extends StatefulWidget {
 }
 
 class _AnimateCameraSampleState extends State<AnimateCameraSample> {
+  // [START maps_flutter_animate_camera]
   /// An instance of map controller obtained through `onMapCreated`.
   GoogleMapController? _controller;
 
@@ -49,6 +50,7 @@ class _AnimateCameraSampleState extends State<AnimateCameraSample> {
 
   @override
   void dispose() {
+    // Prevent erroneous use of controller after widget disposed.
     _controller = null;
     super.dispose();
   }
@@ -63,4 +65,5 @@ class _AnimateCameraSampleState extends State<AnimateCameraSample> {
     // Start the animation.
     _controller?.animateCamera(update);
   }
+  // [END maps_flutter_animate_camera]
 }

--- a/lib/samples/camera_move.dart
+++ b/lib/samples/camera_move.dart
@@ -25,6 +25,7 @@ class MoveCameraSample extends StatefulWidget {
 }
 
 class _MoveCameraSampleState extends State<MoveCameraSample> {
+  // [START maps_flutter_move_camera]
   /// An instance of map controller obtained through `onMapCreated`.
   GoogleMapController? _controller;
 
@@ -49,6 +50,7 @@ class _MoveCameraSampleState extends State<MoveCameraSample> {
 
   @override
   void dispose() {
+    // Prevent erroneous use of controller after widget disposed.
     _controller = null;
     super.dispose();
   }
@@ -62,4 +64,5 @@ class _MoveCameraSampleState extends State<MoveCameraSample> {
     // Move the camera.
     _controller?.moveCamera(update);
   }
+  // [END maps_flutter_move_camera]
 }

--- a/lib/samples/handle_events.dart
+++ b/lib/samples/handle_events.dart
@@ -31,6 +31,7 @@ class _HandleEventsSampleState extends State<HandleEventsSample> {
   Widget build(BuildContext context) {
     return Stack(
       children: [
+        // [START maps_flutter_handle_events]
         GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(0, 0)),
           onTap: (position) => setState(() => _response = 'Tapped $position.'),
@@ -42,6 +43,7 @@ class _HandleEventsSampleState extends State<HandleEventsSample> {
             ),
           },
         ),
+        // [END maps_flutter_handle_events]
         Align(
           alignment: Alignment(0, 0.8),
           child: Card(

--- a/lib/samples/map_controller_async.dart
+++ b/lib/samples/map_controller_async.dart
@@ -28,6 +28,7 @@ class MapControllerAsyncSample extends StatefulWidget {
 }
 
 class _MapControllerAsyncSampleState extends State<MapControllerAsyncSample> {
+  // [START maps_flutter_map_controller_async]
   /// An async completer that we supply with the map controller
   /// as soon as the `onMapCreated` callback is fired.
   final Completer<GoogleMapController> _completer = Completer();
@@ -82,4 +83,5 @@ class _MapControllerAsyncSampleState extends State<MapControllerAsyncSample> {
     // Use the controller.
     controller.animateCamera(CameraUpdate.zoomIn());
   }
+  // [END maps_flutter_map_controller_async]
 }

--- a/lib/samples/map_id.dart
+++ b/lib/samples/map_id.dart
@@ -21,11 +21,13 @@ class MapIdSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_map_id]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(0, 0)),
 
       // Generate your own map ID at https://goo.gle/get-map-id.
       cloudMapId: '78434bee6dc2e9b1',
     );
+    // [END maps_flutter_map_id]
   }
 }

--- a/lib/samples/map_type.dart
+++ b/lib/samples/map_type.dart
@@ -22,6 +22,7 @@ class MapTypeSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_map_type]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(0, 0)),
 
@@ -32,5 +33,6 @@ class MapTypeSample extends StatelessWidget {
       // .hybrid - Satellite imagery with road overlays and place labels
       mapType: MapType.satellite,
     );
+    // [END maps_flutter_map_type]
   }
 }

--- a/lib/samples/marker.dart
+++ b/lib/samples/marker.dart
@@ -22,6 +22,7 @@ class MarkerSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_marker]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(0, 0)),
 
@@ -36,5 +37,6 @@ class MarkerSample extends StatelessWidget {
         ),
       },
     );
+    // [END maps_flutter_marker]
   }
 }

--- a/lib/samples/marker_clusters.dart
+++ b/lib/samples/marker_clusters.dart
@@ -17,6 +17,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 /// Defines a group of nearby markers as a cluster so that the map can
 /// collapse them into a single marker when appropriate.
+// [START maps_flutter_clusters]
 class ClustersSample extends StatelessWidget {
   ClustersSample({super.key});
 
@@ -69,3 +70,4 @@ class ClustersSample extends StatelessWidget {
     );
   }
 }
+// [END maps_flutter_clusters]

--- a/lib/samples/marker_clusters_dynamic.dart
+++ b/lib/samples/marker_clusters_dynamic.dart
@@ -24,6 +24,7 @@ class DynamicClustersSample extends StatefulWidget {
 }
 
 class _DynamicClustersSampleState extends State<DynamicClustersSample> {
+  // [START maps_flutter_dynamic_clusters]
   Set<ClusterManager> _clusters = {};
 
   Set<Marker> _markers = {
@@ -73,4 +74,5 @@ class _DynamicClustersSampleState extends State<DynamicClustersSample> {
       _markers = updatedMarkers;
     });
   }
+  // [END maps_flutter_dynamic_clusters]
 }

--- a/lib/samples/marker_custom.dart
+++ b/lib/samples/marker_custom.dart
@@ -24,6 +24,7 @@ class CustomMarkerSample extends StatefulWidget {
 }
 
 class _CustomMarkerSampleState extends State<CustomMarkerSample> {
+  // [START maps_flutter_custom_marker]
   late Marker _marker = Marker(
     markerId: MarkerId('my_marker'),
     // Start with the default Google Maps pin, except yellow.
@@ -62,4 +63,5 @@ class _CustomMarkerSampleState extends State<CustomMarkerSample> {
       );
     });
   }
+  // [END maps_flutter_custom_marker]
 }

--- a/lib/samples/marker_dynamic.dart
+++ b/lib/samples/marker_dynamic.dart
@@ -24,6 +24,7 @@ class DynamicMarkerSample extends StatefulWidget {
 }
 
 class _DynamicMarkerSampleState extends State<DynamicMarkerSample> {
+  // [START maps_flutter_dynamic_marker]
   /// The dynamic set of markers to be shown on the map.
   /// Marker IDs need to be unique.
   final Set<Marker> _markers = {
@@ -71,4 +72,5 @@ class _DynamicMarkerSampleState extends State<DynamicMarkerSample> {
     // Add the marker with setState.
     setState(() => _markers.add(fishermansWharf));
   }
+  // [END maps_flutter_dynamic_marker]
 }

--- a/lib/samples/my_location.dart
+++ b/lib/samples/my_location.dart
@@ -34,6 +34,7 @@ class _MyLocationSampleState extends State<MyLocationSample> {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_my_location]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(37.78, -122.42)),
 
@@ -49,6 +50,7 @@ class _MyLocationSampleState extends State<MyLocationSample> {
       // This has no effect when `myLocationEnabled` is false.
       myLocationButtonEnabled: true,
     );
+    // [END maps_flutter_my_location]
   }
 
   @override

--- a/lib/samples/polygons.dart
+++ b/lib/samples/polygons.dart
@@ -22,6 +22,7 @@ class PolygonsSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_polygons]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(25, -72)),
       polygons: {
@@ -41,5 +42,6 @@ class PolygonsSample extends StatelessWidget {
         ),
       },
     );
+    // [END maps_flutter_polygons]
   }
 }

--- a/lib/samples/polylines.dart
+++ b/lib/samples/polylines.dart
@@ -22,6 +22,7 @@ class PolylinesSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_polylines]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(49, -23)),
       polylines: {
@@ -48,5 +49,6 @@ class PolylinesSample extends StatelessWidget {
         ),
       },
     );
+    // [END maps_flutter_polylines]
   }
 }

--- a/lib/samples/scrolling.dart
+++ b/lib/samples/scrolling.dart
@@ -24,6 +24,7 @@ class ScrollingSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_scrolling]
     return ListView(
       children: [
         _PlaceholderItem(1),
@@ -61,6 +62,7 @@ class ScrollingSample extends StatelessWidget {
         for (var i = 5; i <= 10; i++) _PlaceholderItem(i),
       ],
     );
+    // [END maps_flutter_scrolling]
   }
 }
 

--- a/lib/samples/styled_map.dart
+++ b/lib/samples/styled_map.dart
@@ -21,6 +21,7 @@ class StyledMapSample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // [START maps_flutter_styled_map]
     return GoogleMap(
       initialCameraPosition: CameraPosition(target: LatLng(0, 0)),
 
@@ -44,5 +45,6 @@ class StyledMapSample extends StatelessWidget {
 ]
       ''',
     );
+    // [END maps_flutter_styled_map]
   }
 }


### PR DESCRIPTION
Adds broad region tags, such as `maps_flutter_animate_camera` for the entirety of the `State` of that sample. More granular region tags are possible if needed.

Also adds to clarifying line comments as a fly by improvement.