### PR TITLE
Add SPDX License Identifier to header

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 version: 2
 updates:

--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 name: Run code analysis
 on:

--- a/.github/workflows/licence-check.yaml
+++ b/.github/workflows/licence-check.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 name: Check license headers
 on:

--- a/.github/workflows/scripts/validate-formatting.sh
+++ b/.github/workflows/scripts/validate-formatting.sh
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 if [[ $(git ls-files --modified) ]]; then

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 name: Build samples
 on:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 include: package:flutter_lints/flutter.yaml
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     id "com.android.application"

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -12,6 +12,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
             android:value="2" />
         <!-- Google Maps API Key -->
         <meta-data android:name="com.google.android.geo.API_KEY"
-                   android:value="AIzaSyD64FPq_Hf-ladFapnQCACdcpgwAtJ---M"/>
+                   android:value="AIzaSyAS1zaJLBxG14nJUM8LLtDjN2imbFugmLk"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -52,7 +54,7 @@
             android:value="2" />
         <!-- Google Maps API Key -->
         <meta-data android:name="com.google.android.geo.API_KEY"
-                   android:value="AIzaSyAS1zaJLBxG14nJUM8LLtDjN2imbFugmLk"/>
+                   android:value="AIzaSyD64FPq_Hf-ladFapnQCACdcpgwAtJ---M"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/flutter_maps_samples/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_maps_samples/MainActivity.kt
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.example.flutter_maps_samples

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -13,6 +13,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <!-- Modify this file to customize your launch splash screen -->

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -13,6 +13,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <!-- Modify this file to customize your launch splash screen -->

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -13,6 +13,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -13,6 +13,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <resources>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -12,6 +12,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 allprojects {
     repositories {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 pluginManagement {
     def flutterSdkPath = {

--- a/header_template.txt
+++ b/header_template.txt
@@ -12,6 +12,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-@license
-Copyright 2025 Google LLC. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/header_template.txt
+++ b/header_template.txt
@@ -11,3 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+@license
+Copyright 2025 Google LLC. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import Flutter
 import UIKit

--- a/ios/Runner/Runner-Bridging-Header.h
+++ b/ios/Runner/Runner-Bridging-Header.h
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #import "GeneratedPluginRegistrant.h"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:flutter_maps_samples/samples/basic.dart';
@@ -51,6 +53,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
         useMaterial3: true,
       ),
+      debugShowCheckedModeBanner: false,
       home: const MyHomePage(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,7 +53,6 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
         useMaterial3: true,
       ),
-      debugShowCheckedModeBanner: false,
       home: const MyHomePage(),
     );
   }

--- a/lib/samples/basic.dart
+++ b/lib/samples/basic.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/camera_animate.dart
+++ b/lib/samples/camera_animate.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/camera_move.dart
+++ b/lib/samples/camera_move.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/handle_events.dart
+++ b/lib/samples/handle_events.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/map_controller_async.dart
+++ b/lib/samples/map_controller_async.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/samples/map_id.dart
+++ b/lib/samples/map_id.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/map_type.dart
+++ b/lib/samples/map_type.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/marker.dart
+++ b/lib/samples/marker.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/marker_clusters.dart
+++ b/lib/samples/marker_clusters.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/marker_clusters_dynamic.dart
+++ b/lib/samples/marker_clusters_dynamic.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/marker_custom.dart
+++ b/lib/samples/marker_custom.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/marker_dynamic.dart
+++ b/lib/samples/marker_dynamic.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/my_location.dart
+++ b/lib/samples/my_location.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/lib/samples/polygons.dart
+++ b/lib/samples/polygons.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/polylines.dart
+++ b/lib/samples/polylines.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/lib/samples/scrolling.dart
+++ b/lib/samples/scrolling.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/lib/samples/styled_map.dart
+++ b/lib/samples/styled_map.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';

--- a/melos.yaml
+++ b/melos.yaml
@@ -79,7 +79,7 @@ scripts:
     # If you add here another --ignore flag, add it also to
     # "check-license-header".
     run: |
-      addlicense -s -f header_template.txt \
+      addlicense -f header_template.txt \
         --ignore ".idea/**" \
         --ignore "android/app/.cxx/**" \
         --ignore "**/Pods/**" \
@@ -97,7 +97,7 @@ scripts:
     # If you add here another --ignore flag, add it also to
     # "add-license-header".
     run: |
-      addlicense -s -f header_template.txt \
+      addlicense -f header_template.txt \
         --check \
         --ignore ".idea/**" \
         --ignore "android/app/.cxx/**" \

--- a/melos.yaml
+++ b/melos.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 name: flutter_maps_samples
 repository: https://github.com/googlemaps-samples/flutter-maps-samples
@@ -77,7 +79,7 @@ scripts:
     # If you add here another --ignore flag, add it also to
     # "check-license-header".
     run: |
-      addlicense -f header_template.txt \
+      addlicense -s -f header_template.txt \
         --ignore ".idea/**" \
         --ignore "android/app/.cxx/**" \
         --ignore "**/Pods/**" \
@@ -95,7 +97,7 @@ scripts:
     # If you add here another --ignore flag, add it also to
     # "add-license-header".
     run: |
-      addlicense -f header_template.txt \
+      addlicense -s -f header_template.txt \
         --check \
         --ignore ".idea/**" \
         --ignore "android/app/.cxx/**" \

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 name: flutter_maps_samples
 description: "A demo of Google Maps SDK for Flutter."

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:io';
 

--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <html>


### PR DESCRIPTION
Adding

    SPDX-License-Identifier: Apache-2.0

to the license header.

I opted for simply adding the single machine-readable line, which is what `addlicense -s` ("Include SPDX identifier in license header.") does. Adding more than that (such as `@license`) would be duplicitous.

