### PR TITLE
Cease pinning CI Flutter to minor version number

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         with:
-          flutter-version: "3.29.x"
+          flutter-version: "3.x"
           channel: "stable"
           cache: true
       - name: Setup melos
@@ -57,7 +57,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         with:
-          flutter-version: "3.29.x"
+          flutter-version: "3.x"
           channel: "stable"
           cache: true
       - name: Setup melos

--- a/.github/workflows/licence-check.yaml
+++ b/.github/workflows/licence-check.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         with:
-          flutter-version: "3.29.x"
+          flutter-version: "3.x"
           channel: "stable"
           cache: true
       - name: Install Melos

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         name: Setup flutter
         with:
-          flutter-version: "3.29.x"
+          flutter-version: "3.x"
           channel: "stable"
           cache: true
       - uses: bluefireteam/melos-action@ec2c512a52c2f359186ca19bac0be977c44913e6
@@ -71,7 +71,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         with:
-          flutter-version: "3.29.x"
+          flutter-version: "3.x"
           channel: "stable"
           cache: true
       - name: Setup melos
@@ -96,7 +96,7 @@ jobs:
       - name: Setup flutter
         uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         with:
-          flutter-version: "3.29.x"
+          flutter-version: "3.x"
           channel: "stable"
           cache: true
           architecture: x64


### PR DESCRIPTION
Instead, the CI will now upgrade Flutter to latest stable version (as long as it’s 3.x). This is a better trade-off for a sample repo. We don’t need to update several lines in 3 separate YAML files every 3 months. Since this is a small sample repo, it is very unlikely that a minor stable release will break anything.