### PR TITLE
Add EEA notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ please [file an issue](https://github.com/googlemaps-samples/flutter-maps-sample
 
 Patches are encouraged, and may be submitted according to the instructions in
 CONTRIBUTING.md.
+
+European Economic Area (EEA) developers
+---------------------------------------
+
+If your billing address is in the European Economic Area,
+effective on 8 July 2025, the
+[Google Maps Platform EEA Terms of Service](https://cloud.google.com/terms/maps-platform/eea)
+will apply to your use of the Services.
+Functionality varies by region.
+[Learn more](https://developers.google.com/maps/comms/eea/faq).


### PR DESCRIPTION
Adds a notice to the README that links to [Google Maps Platform EEA Terms of Service](https://cloud.google.com/terms/maps-platform/eea) and [EEA FAQ](https://developers.google.com/maps/comms/eea/faq).

The section is at the bottom and looks like this when rendered on github:

![Screenshot 2025-07-03 at 11 34 58](https://github.com/user-attachments/assets/9ae3e5ff-fc00-4ccf-913b-de14022d84e0)
